### PR TITLE
Corrections to db_bb.grinch_tdc.dat and replay_BBGEM_3.odef

### DIFF
--- a/DB/db_bb.grinch_tdc.dat
+++ b/DB/db_bb.grinch_tdc.dat
@@ -257,7 +257,7 @@ bb.grinch_tdc.trackmatch_xmax = -0.45 0.1 0.6 0.85
 bb.grinch_tdc.trackmatch_nsigma_cut = 5.0
 
 bb.grinch_tdc.hit_mintime = -30
-bb.grinch_tdc.hit.maxtime = 30
+bb.grinch_tdc.hit_maxtime = 30
 
 
 ---------[ 2021-12-01 12:00:00 ] # timing shift during SBS-11:
@@ -268,7 +268,7 @@ bb.grinch_tdc.hit_maxtime =  -40
 ---------[ 2021-12-14 12:00:00 ] # second timing shift during SBS-11:
 
 bb.grinch_tdc.hit_mintime = -30
-bb.grinch_tdc.hit.maxtime = 30
+bb.grinch_tdc.hit_maxtime = 30
 
 
 

--- a/replay/replay_BBGEM_3.odef
+++ b/replay/replay_BBGEM_3.odef
@@ -227,35 +227,35 @@ th1d hbb_gem_m7_ADCsum_deconv_good 'bb gem m7 (strips on tracks); Sum of deconvo
 th1d hbb_gem_m7_ADCmax_deconv_good 'bb gem m7 (strips on tracks); Max. deconvoluted sample;' bb.gem.m7.strip.DeconvADCmax[I] 400 -500 3500 bb.gem.m7.strip.ontrack[I]
 th1d hbb_gem_m7_isampmax_deconv_good 'bb gem m7 (strips on tracks); peak deconvoluted sample;' bb.gem.m7.strip.isampmaxDeconv[I] 6 -0.5 5.5 bb.gem.m7.strip.ontrack[I]
 
-# deconvolution stuff:
-th1d hbb_gem_m8_Tdeconv_all 'bb gem m8 (all strips); Mean deconvoluted strip time (ns);' bb.gem.m8.strip.TmeanDeconv 200 -100 300
-th1d hbb_gem_m8_ADCsum_deconv_all 'bb gem m8 (all strips); Sum of deconvoluted samples;' bb.gem.m8.strip.DeconvADCsum 400 -500 3500
-th1d hbb_gem_m8_ADCmax_deconv_all 'bb gem m8 (all strips); Max. deconvoluted sample;' bb.gem.m8.strip.DeconvADCmax 400 -500 3500
-th1d hbb_gem_m8_isampmax_deconv_all 'bb gem m8 (all strips); peak deconvoluted sample;' bb.gem.m8.strip.isampmaxDeconv 6 -0.5 5.5
-th1d hbb_gem_m8_Tdeconv_good 'bb gem m8 (strips on tracks); Mean deconvoluted strip time (ns);' bb.gem.m8.strip.TmeanDeconv[I] 200 -100 300 bb.gem.m8.strip.ontrack[I]
-th1d hbb_gem_m8_ADCsum_deconv_good 'bb gem m8 (strips on tracks); Sum of deconvoluted samples;' bb.gem.m8.strip.DeconvADCsum[I] 400 -500 3500 bb.gem.m8.strip.ontrack[I]
-th1d hbb_gem_m8_ADCmax_deconv_good 'bb gem m8 (strips on tracks); Max. deconvoluted sample;' bb.gem.m8.strip.DeconvADCmax[I] 400 -500 3500 bb.gem.m8.strip.ontrack[I]
-th1d hbb_gem_m8_isampmax_deconv_good 'bb gem m8 (strips on tracks); peak deconvoluted sample;' bb.gem.m8.strip.isampmaxDeconv[I] 6 -0.5 5.5 bb.gem.m8.strip.ontrack[I]
+# # deconvolution stuff:
+# th1d hbb_gem_m8_Tdeconv_all 'bb gem m8 (all strips); Mean deconvoluted strip time (ns);' bb.gem.m8.strip.TmeanDeconv 200 -100 300
+# th1d hbb_gem_m8_ADCsum_deconv_all 'bb gem m8 (all strips); Sum of deconvoluted samples;' bb.gem.m8.strip.DeconvADCsum 400 -500 3500
+# th1d hbb_gem_m8_ADCmax_deconv_all 'bb gem m8 (all strips); Max. deconvoluted sample;' bb.gem.m8.strip.DeconvADCmax 400 -500 3500
+# th1d hbb_gem_m8_isampmax_deconv_all 'bb gem m8 (all strips); peak deconvoluted sample;' bb.gem.m8.strip.isampmaxDeconv 6 -0.5 5.5
+# th1d hbb_gem_m8_Tdeconv_good 'bb gem m8 (strips on tracks); Mean deconvoluted strip time (ns);' bb.gem.m8.strip.TmeanDeconv[I] 200 -100 300 bb.gem.m8.strip.ontrack[I]
+# th1d hbb_gem_m8_ADCsum_deconv_good 'bb gem m8 (strips on tracks); Sum of deconvoluted samples;' bb.gem.m8.strip.DeconvADCsum[I] 400 -500 3500 bb.gem.m8.strip.ontrack[I]
+# th1d hbb_gem_m8_ADCmax_deconv_good 'bb gem m8 (strips on tracks); Max. deconvoluted sample;' bb.gem.m8.strip.DeconvADCmax[I] 400 -500 3500 bb.gem.m8.strip.ontrack[I]
+# th1d hbb_gem_m8_isampmax_deconv_good 'bb gem m8 (strips on tracks); peak deconvoluted sample;' bb.gem.m8.strip.isampmaxDeconv[I] 6 -0.5 5.5 bb.gem.m8.strip.ontrack[I]
 
-# deconvolution stuff:
-th1d hbb_gem_m9_Tdeconv_all 'bb gem m9 (all strips); Mean deconvoluted strip time (ns);' bb.gem.m9.strip.TmeanDeconv 200 -100 300
-th1d hbb_gem_m9_ADCsum_deconv_all 'bb gem m9 (all strips); Sum of deconvoluted samples;' bb.gem.m9.strip.DeconvADCsum 400 -500 3500
-th1d hbb_gem_m9_ADCmax_deconv_all 'bb gem m9 (all strips); Max. deconvoluted sample;' bb.gem.m9.strip.DeconvADCmax 400 -500 3500
-th1d hbb_gem_m9_isampmax_deconv_all 'bb gem m9 (all strips); peak deconvoluted sample;' bb.gem.m9.strip.isampmaxDeconv 6 -0.5 5.5
-th1d hbb_gem_m9_Tdeconv_good 'bb gem m9 (strips on tracks); Mean deconvoluted strip time (ns);' bb.gem.m9.strip.TmeanDeconv[I] 200 -100 300 bb.gem.m9.strip.ontrack[I]
-th1d hbb_gem_m9_ADCsum_deconv_good 'bb gem m9 (strips on tracks); Sum of deconvoluted samples;' bb.gem.m9.strip.DeconvADCsum[I] 400 -500 3500 bb.gem.m9.strip.ontrack[I]
-th1d hbb_gem_m9_ADCmax_deconv_good 'bb gem m9 (strips on tracks); Max. deconvoluted sample;' bb.gem.m9.strip.DeconvADCmax[I] 400 -500 3500 bb.gem.m9.strip.ontrack[I]
-th1d hbb_gem_m9_isampmax_deconv_good 'bb gem m9 (strips on tracks); peak deconvoluted sample;' bb.gem.m9.strip.isampmaxDeconv[I] 6 -0.5 5.5 bb.gem.m9.strip.ontrack[I]
+# # deconvolution stuff:
+# th1d hbb_gem_m9_Tdeconv_all 'bb gem m9 (all strips); Mean deconvoluted strip time (ns);' bb.gem.m9.strip.TmeanDeconv 200 -100 300
+# th1d hbb_gem_m9_ADCsum_deconv_all 'bb gem m9 (all strips); Sum of deconvoluted samples;' bb.gem.m9.strip.DeconvADCsum 400 -500 3500
+# th1d hbb_gem_m9_ADCmax_deconv_all 'bb gem m9 (all strips); Max. deconvoluted sample;' bb.gem.m9.strip.DeconvADCmax 400 -500 3500
+# th1d hbb_gem_m9_isampmax_deconv_all 'bb gem m9 (all strips); peak deconvoluted sample;' bb.gem.m9.strip.isampmaxDeconv 6 -0.5 5.5
+# th1d hbb_gem_m9_Tdeconv_good 'bb gem m9 (strips on tracks); Mean deconvoluted strip time (ns);' bb.gem.m9.strip.TmeanDeconv[I] 200 -100 300 bb.gem.m9.strip.ontrack[I]
+# th1d hbb_gem_m9_ADCsum_deconv_good 'bb gem m9 (strips on tracks); Sum of deconvoluted samples;' bb.gem.m9.strip.DeconvADCsum[I] 400 -500 3500 bb.gem.m9.strip.ontrack[I]
+# th1d hbb_gem_m9_ADCmax_deconv_good 'bb gem m9 (strips on tracks); Max. deconvoluted sample;' bb.gem.m9.strip.DeconvADCmax[I] 400 -500 3500 bb.gem.m9.strip.ontrack[I]
+# th1d hbb_gem_m9_isampmax_deconv_good 'bb gem m9 (strips on tracks); peak deconvoluted sample;' bb.gem.m9.strip.isampmaxDeconv[I] 6 -0.5 5.5 bb.gem.m9.strip.ontrack[I]
 
-# deconvolution stuff:
-th1d hbb_gem_m10_Tdeconv_all 'bb gem m10 (all strips); Mean deconvoluted strip time (ns);' bb.gem.m10.strip.TmeanDeconv 200 -100 300
-th1d hbb_gem_m10_ADCsum_deconv_all 'bb gem m10 (all strips); Sum of deconvoluted samples;' bb.gem.m10.strip.DeconvADCsum 400 -500 3500
-th1d hbb_gem_m10_ADCmax_deconv_all 'bb gem m10 (all strips); Max. deconvoluted sample;' bb.gem.m10.strip.DeconvADCmax 400 -500 3500
-th1d hbb_gem_m10_isampmax_deconv_all 'bb gem m10 (all strips); peak deconvoluted sample;' bb.gem.m10.strip.isampmaxDeconv 6 -0.5 5.5
-th1d hbb_gem_m10_Tdeconv_good 'bb gem m10 (strips on tracks); Mean deconvoluted strip time (ns);' bb.gem.m10.strip.TmeanDeconv[I] 200 -100 300 bb.gem.m10.strip.ontrack[I]
-th1d hbb_gem_m10_ADCsum_deconv_good 'bb gem m10 (strips on tracks); Sum of deconvoluted samples;' bb.gem.m10.strip.DeconvADCsum[I] 400 -500 3500 bb.gem.m10.strip.ontrack[I]
-th1d hbb_gem_m10_ADCmax_deconv_good 'bb gem m10 (strips on tracks); Max. deconvoluted sample;' bb.gem.m10.strip.DeconvADCmax[I] 400 -500 3500 bb.gem.m10.strip.ontrack[I]
-th1d hbb_gem_m10_isampmax_deconv_good 'bb gem m10 (strips on tracks); peak deconvoluted sample;' bb.gem.m10.strip.isampmaxDeconv[I] 6 -0.5 5.5 bb.gem.m10.strip.ontrack[I]
+# # deconvolution stuff:
+# th1d hbb_gem_m10_Tdeconv_all 'bb gem m10 (all strips); Mean deconvoluted strip time (ns);' bb.gem.m10.strip.TmeanDeconv 200 -100 300
+# th1d hbb_gem_m10_ADCsum_deconv_all 'bb gem m10 (all strips); Sum of deconvoluted samples;' bb.gem.m10.strip.DeconvADCsum 400 -500 3500
+# th1d hbb_gem_m10_ADCmax_deconv_all 'bb gem m10 (all strips); Max. deconvoluted sample;' bb.gem.m10.strip.DeconvADCmax 400 -500 3500
+# th1d hbb_gem_m10_isampmax_deconv_all 'bb gem m10 (all strips); peak deconvoluted sample;' bb.gem.m10.strip.isampmaxDeconv 6 -0.5 5.5
+# th1d hbb_gem_m10_Tdeconv_good 'bb gem m10 (strips on tracks); Mean deconvoluted strip time (ns);' bb.gem.m10.strip.TmeanDeconv[I] 200 -100 300 bb.gem.m10.strip.ontrack[I]
+# th1d hbb_gem_m10_ADCsum_deconv_good 'bb gem m10 (strips on tracks); Sum of deconvoluted samples;' bb.gem.m10.strip.DeconvADCsum[I] 400 -500 3500 bb.gem.m10.strip.ontrack[I]
+# th1d hbb_gem_m10_ADCmax_deconv_good 'bb gem m10 (strips on tracks); Max. deconvoluted sample;' bb.gem.m10.strip.DeconvADCmax[I] 400 -500 3500 bb.gem.m10.strip.ontrack[I]
+# th1d hbb_gem_m10_isampmax_deconv_good 'bb gem m10 (strips on tracks); peak deconvoluted sample;' bb.gem.m10.strip.isampmaxDeconv[I] 6 -0.5 5.5 bb.gem.m10.strip.ontrack[I]
 
 
 # Module-specific histograms: 


### PR DESCRIPTION
Corrected typo to DB/db_bb.grinch_tdc.dat which was causing affected timestamped grinch data to be improperly cut and consequently missing. 

Commented gem histograms from replay_BBGEM_3.odef referencing GEMs (m8, m9, m10) that do not exist on GMn data set, throwing many errors when running replay_gmn.C but not affecting the replayed output. Verified that replay_gen.C does not use this .odef file.