### PR TITLE
loosened bbcal tmax cuts for GEn and GEn-RP

### DIFF
--- a/DB/db_bb.ps.dat
+++ b/DB/db_bb.ps.dat
@@ -1704,6 +1704,10 @@ bb.ps.adc.gain =
 ## Starting from run 1475
 -------[ 2022-09-19 23:00:00 ]
 
+## Maximum time difference between cluster seed and additional clusters, set to 1000 ns by default
+# keep this cut wider until we more fully understand its effect:
+bb.ps.tmax = 50.0
+
 #ADCtime offsets w.r.t. bbhodo time
 bb.ps.adc.timeoffset =
 -2.0531 -1.91299
@@ -2368,6 +2372,10 @@ bb.ps.adc.gain =
 ## Starting from run 
 
 -------[ 2024-04-04 23:00:00 ]
+
+## Maximum time difference between cluster seed and additional clusters, set to 1000 ns by default
+# keep this cut wider until we more fully understand its effect:
+bb.ps.tmax = 50.0
 
 ##ADCtime offsets w.r.t. bbhodo time
 #bb.ps.adc.timeoffset =

--- a/DB/db_bb.sh.dat
+++ b/DB/db_bb.sh.dat
@@ -1830,6 +1830,10 @@ bb.sh.adc.gain =
 ## Starting from run 1475
 -------[ 2022-09-19 23:00:00 ]
 
+## Maximum time difference between cluster seed and additional blocks, set to 1000 ns
+# keep at 50 ns until we better understand the effects:
+bb.sh.tmax = 50.0
+
 ## ADCtime offsets using cosmic data (Target ADC time = 40 ns)
 ## Used cosmic run 1462
 bb.sh.adc.timeoffset =
@@ -2513,6 +2517,10 @@ bb.sh.adc.gain =
 ## Starting from run 1475
 
 -------[ 2024-04-04 23:00:00 ]
+
+## Maximum time difference between cluster seed and additional blocks, set to 1000 ns
+# keep at 50 ns until we better understand the effects:
+bb.sh.tmax = 50.0
 
 ## ADCtime offsets using cosmic data (Target ADC time = 40 ns)
 ## Used cosmic run 1462


### PR DESCRIPTION
These cuts were lowered for GMn (tmax = 10ns), but for GEn and GEn-RP we should be working with a looser cut so as not to introduce biases to the energy calibrations. Under recommendations from Provakar, I added a 50ns tmax cut to the start of GEn and GEn-RP. If I tighten this cut for GEn, then GEn-RP will remain unaffected.