### PR TITLE
FTROI variable block removed from replay_sbs_genrp.odef

### DIFF
--- a/replay/replay_sbs_genrp.odef
+++ b/replay/replay_sbs_genrp.odef
@@ -33,7 +33,7 @@ variable sbs.z_bcp_FPP
 
 block sbs.tdctrig.*
 
-block FTROI.*
+#block FTROI.* #GEP only
 
 block SBS.gold.*
 


### PR DESCRIPTION
FTROI variable block removed from replay_sbs_genrp.odef. That variable block was added my mistake and used for GEP only